### PR TITLE
fix: メニューのスタイル、アニメーション調整(#6)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -586,7 +586,10 @@ a {
 
 .menu {
   position: fixed;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: 1200;
   width: 100%;
   height: 100%;
@@ -594,7 +597,8 @@ a {
   visibility: hidden;
   background-color: var(--white);
   opacity: 0;
-  transition: opacity 0.3s, visibility 0s ease 1s;
+  transition: opacity 0.3s, visibility 0.3s ease 0.3s, transform 0.3s;
+  transform: translateX(100%);
 }
 
 .menu-header {
@@ -635,6 +639,7 @@ a {
   visibility: visible;
   opacity: 1;
   transition-delay: 0s;
+  transform: translateX(0);
 }
 
 /* tablet

--- a/index.html
+++ b/index.html
@@ -276,21 +276,23 @@
         </small>
       </footer>
     </div>
-    <div id="menu" class="outside-container menu menu--close">
-      <div class="menu-header">
-        <button id="close-menu-btn" type="button" class="menu-btn">
-          <span class="material-icons"> close </span>
-        </button>
+    <div id="menu" class="menu">
+      <div class="outside-container">
+        <div class="menu-header">
+          <button id="close-menu-btn" type="button" class="menu-btn">
+            <span class="material-icons"> close </span>
+          </button>
+        </div>
+        <nav id="menu-nav" class="menu-nav">
+          <ul id="menu-nav-list" class="nav-list menu-nav-list">
+            <li><a href="#top-header">Home</a></li>
+            <li><a href="#services">Services</a></li>
+            <li><a href="#our-works">Our Works</a></li>
+            <li><a href="#clients">Clients</a></li>
+            <li><a href="#footer">Contact</a></li>
+          </ul>
+        </nav>
       </div>
-      <nav id="menu-nav" class="menu-nav">
-        <ul id="menu-nav-list" class="nav-list menu-nav-list">
-          <li><a href="#top-header">Home</a></li>
-          <li><a href="#services">Services</a></li>
-          <li><a href="#our-works">Our Works</a></li>
-          <li><a href="#clients">Clients</a></li>
-          <li><a href="#footer">Contact</a></li>
-        </ul>
-      </nav>
     </div>
     <script type="module" src="/js/main.js"></script>
   </body>


### PR DESCRIPTION
## Issue 番号
closes #6

## 対応内容
- inset は Safari が新しめのバージョンじゃないと対応していないので、top, right, left, bottom と個別にした
- メニュー開閉時のアニメーションをスライドイン・アウトも兼ねるようにして、スクロールバー問題を目立たなくした