### PR TITLE
teamセクションの画像サイズがおかしくなる問題修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -429,19 +429,19 @@ a {
   border-radius: 24px;
 }
 
-.team-section__team-member-img-list img:nth-child(1) {
+.team-section__team-member-img-list p:nth-child(1) {
   grid-row: 1 / 3;
   grid-column: 2 / 3;
   width: 90%;
   height: 90%;
 }
 
-.team-section__team-member-img-list img:nth-child(2) {
+.team-section__team-member-img-list p:nth-child(2) {
   grid-row: 3 / 5;
   grid-column: 2 / 3;
 }
 
-.team-section__team-member-img-list img:nth-child(3) {
+.team-section__team-member-img-list p:nth-child(3) {
   grid-row: 2 / 4;
   grid-column: 1 / 2;
 }

--- a/index.html
+++ b/index.html
@@ -204,9 +204,9 @@
               </p>
             </div>
             <div class="team-section__team-member-img-list">
-              <img src="./images/person1.png" alt="" />
-              <img src="./images/person2.png" alt="" />
-              <img src="./images/person3.png" alt="" />
+              <p><img src="./images/person1.png" alt="" /></p>
+              <p><img src="./images/person2.png" alt="" /></p>
+              <p><img src="./images/person3.png" alt="" /></p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Issue 番号
closes #8 

## 対応内容
- team セクションの画像を p タグで囲って、サイズが崩れないようにした。