### PR TITLE
Chromeでページ初期読み込みに、一瞬メニューがちらつく現象対応(#11)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -39,6 +39,11 @@ a {
   box-sizing: border-box;
 }
 
+/* load ※Chromeのページ初期読み込み時のtransition抑制対応 */
+.js-preload * {
+  transition: none !important;
+}
+
 /* common
 -------------------- */
 

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       rel="stylesheet"
     />
   </head>
-  <body>
+  <body class="js-preload">
     <div id="contents">
       <header id="top-header" class="top-header">
         <div class="outside-container top-header__layout">

--- a/js/main.js
+++ b/js/main.js
@@ -70,3 +70,9 @@ window.addEventListener('DOMContentLoaded', () => {
     link.addEventListener('click', closeMenu);
   });
 });
+
+window.addEventListener('load', () => {
+  document
+    .getElementsByClassName('js-preload')[0]
+    .classList.remove('js-preload');
+});


### PR DESCRIPTION
## Issue 番号
closes #11 

## 対応内容
- あらかじめ trasition 抑制用クラスを付与しておき、ページ読み込み後に外すようにした。