### PR TITLE
focus-visibleもpostcss-preset-env経由で使用するようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ menu
 
 Other major libraries
 - [material-design-icons](https://google.github.io/material-design-icons/)
-- [focus-visible](https://github.com/WICG/focus-visible)
 - [wicg-inert](https://github.com/WICG/inert)
+- [postcss-preset-env](https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env)
 
 ## Features
 

--- a/css/style.css
+++ b/css/style.css
@@ -136,7 +136,7 @@ a {
   transition: background-color 0.3s;
 }
 
-.custom-email-input button:not(.focus-visible) {
+.custom-email-input button:not(:focus-visible) {
   outline-color: transparent;
 }
 
@@ -600,7 +600,10 @@ a {
   visibility: hidden;
   background-color: var(--white);
   opacity: 0;
-  transition: opacity 0.3s, visibility 0.3s ease 0.3s, transform 0.3s;
+  transition:
+    opacity 0.3s,
+    visibility 0.3s ease 0.3s,
+    transform 0.3s;
   transform: translateX(100%);
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,4 @@
 import '../css/style.css';
-import 'focus-visible';
 import 'wicg-inert';
 
 const contents = document.getElementById('contents');

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  plugins: [require('postcss-preset-env')],
+  plugins: [
+    require('postcss-preset-env')({
+      features: {
+        'focus-visible-pseudo-class': { enableClientSidePolyfills: true },
+      },
+    }),
+  ],
 };


### PR DESCRIPTION
## Issue 番号
<!-- ※マージとともクローズの場合は closes をつける -->
closes #19 

## 対応内容
- focus-visible も postcss-preset-env 経由で使用するようにした
  - 別パッケージのポリフィルを読み込むよう設定を追加
  - 元々、focus-visible をインポートしていたのを削除